### PR TITLE
Migrate to ggplot2 v4.0.0 (S7 compatibility)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,9 +15,9 @@ Description:
     that can be easily modified via regular ggplot2 syntax. In addition, it 
     provides a large set of visualization tools for exploratory data analysis 
     based on correlation matrices.
-Depends: 
-    R (>= 3.6.0),
-    ggplot2 (>= 3.2.1)
+Depends:
+    R (>= 4.1.0),
+    ggplot2 (>= 4.0.0)
 Imports:
     rlang,
     grid,

--- a/R/add_corrtext.R
+++ b/R/add_corrtext.R
@@ -19,7 +19,7 @@
 #'   (defaults to 2).
 #' @param corr_size logical - should the `size` aesthetic be expressed as a
 #'   function of correlation strength? `corr_size = TRUE` is a shorthand for
-#'   setting `aes(size = abs(..corr..))`. Similar expressions can be used to
+#'   setting `aes(size = abs(after_stat(corr)))`. Similar expressions can be used to
 #'   access the correlation calculated by `stat_corrtext` manually in `aes()`.
 #'   Defaults to `TRUE`.
 #' @param corr_method character string with the correlation method passed to
@@ -70,7 +70,7 @@ lotri_corrtext <- function(mapping = NULL, nrow = NULL, ncol = NULL,
 
   # update and check mapping
   if(corr_size) {
-    mapping <- update_aes_corrm(mapping, standard_aes = c(x = "x", y = "y", size = "abs(..corr..)"))
+    mapping <- update_aes_corrm(mapping, standard_aes = c(x = "x", y = "y", size = "abs(after_stat(corr))"))
   } else {
     mapping <- update_aes_corrm(mapping)
   }
@@ -98,7 +98,7 @@ utri_corrtext <- function(mapping = NULL, nrow = NULL, ncol = NULL,
 
   # update and check mapping
   if(corr_size) {
-    mapping <- update_aes_corrm(mapping, standard_aes = c(x = "x", y = "y", size = "abs(..corr..)"))
+    mapping <- update_aes_corrm(mapping, standard_aes = c(x = "x", y = "y", size = "abs(after_stat(corr))"))
   } else {
     mapping <- update_aes_corrm(mapping)
   }

--- a/R/add_funtext.R
+++ b/R/add_funtext.R
@@ -12,7 +12,7 @@
 #' @param mapping Set of aesthetic mappings created by [aes()][ggplot2::aes()]. x
 #'   and y are set automatically and must not bechanged, but all other
 #'   aesthetics may be manipulated. By default, the `fill` aesthetic is mapped
-#'   to `..fun_out..` internally, but this is overridden when explicitly
+#'   to `after_stat(fun_out)` internally, but this is overridden when explicitly
 #'   specified. Defaults to `NULL` (use standard settings).
 #' @param ... Additional arguments to [stat_funtext].
 #'
@@ -70,7 +70,7 @@ lotri_funtext <- function(fun, mapping = NULL,
   # update and check mapping
   mapping <- update_aes_corrm(
     new_aes      = mapping,
-    standard_aes = c(x = "x", y = "y", label = "..fun_out..")
+    standard_aes = c(x = "x", y = "y", label = "after_stat(fun_out)")
     )
 
 
@@ -91,7 +91,7 @@ utri_funtext <- function(fun, mapping = NULL,
   # update and check mapping
   mapping <- update_aes_corrm(
     new_aes      = mapping,
-    standard_aes = c(x = "x", y = "y", label = "..fun_out..")
+    standard_aes = c(x = "x", y = "y", label = "after_stat(fun_out)")
   )
 
   # return plot with labels

--- a/R/add_heatcircle.R
+++ b/R/add_heatcircle.R
@@ -40,7 +40,7 @@ lotri_heatcircle <- function(mapping = NULL,
   # update and check mapping
   mapping <- update_aes_corrm(
     new_aes      = mapping,
-    standard_aes = c(x = "x", y = "y", fill = "..corr..")
+    standard_aes = c(x = "x", y = "y", fill = "after_stat(corr)")
   )
 
   # prepare scale argument
@@ -67,7 +67,7 @@ utri_heatcircle <- function(mapping = NULL,
   # update and check mapping
   mapping <- update_aes_corrm(
     new_aes      = mapping,
-    standard_aes = c(x = "x", y = "y", fill = "..corr..")
+    standard_aes = c(x = "x", y = "y", fill = "after_stat(corr)")
   )
 
   # prepare scale argument

--- a/R/add_heatmap.R
+++ b/R/add_heatmap.R
@@ -39,7 +39,7 @@ lotri_heatmap <- function(corr_method = NULL, ...) {
   # update and check mapping
   mapping <- update_aes_corrm(
     new_aes = NULL,
-    standard_aes = c(x = "x", y = "y", fill = "..corr..")
+    standard_aes = c(x = "x", y = "y", fill = "after_stat(corr)")
   )
 
   # return plot with labels
@@ -59,7 +59,7 @@ utri_heatmap <- function(corr_method = NULL, ...) {
   # update and check mapping
   mapping <- update_aes_corrm(
     new_aes = NULL,
-    standard_aes = c(x = "x", y = "y", fill = "..corr..")
+    standard_aes = c(x = "x", y = "y", fill = "after_stat(corr)")
     )
 
   # return plot with labels
@@ -79,7 +79,7 @@ lotri_heatpoint <- function(corr_size = TRUE, mapping = NULL, corr_method = NULL
 
   # update and check mapping
   if(corr_size) {
-    mapping <- update_aes_corrm(mapping, standard_aes = c(x = "x", y = "y", size = "abs(..corr..)"))
+    mapping <- update_aes_corrm(mapping, standard_aes = c(x = "x", y = "y", size = "abs(after_stat(corr))"))
   } else {
     mapping <- update_aes_corrm(mapping)
   }
@@ -101,7 +101,7 @@ utri_heatpoint <- function(corr_size = TRUE, mapping = NULL, corr_method = NULL,
 
   # update and check mapping
   if(corr_size) {
-    mapping <- update_aes_corrm(mapping, standard_aes = c(x = "x", y = "y", size = "abs(..corr..)"))
+    mapping <- update_aes_corrm(mapping, standard_aes = c(x = "x", y = "y", size = "abs(after_stat(corr))"))
   } else {
     mapping <- update_aes_corrm(mapping)
   }

--- a/R/corrmorant_package.R
+++ b/R/corrmorant_package.R
@@ -74,19 +74,7 @@ NULL
 #' @importFrom stats density
 NULL
 
-# getFromNamespace for internal ggplot2 functions
-#' @importFrom utils getFromNamespace
-NULL
-
 # gList from grid for custom geoms
 #' @importFrom grid gList
 NULL
-
-# standard build method for ggplot objects
-#' @keywords internal
-ggplot_build.ggplot <- utils::getFromNamespace("ggplot_build.ggplot", "ggplot2")
-
-# construct labels for aesthetics
-#' @keywords internal
-make_labels <- utils::getFromNamespace("make_labels", "ggplot2")
 

--- a/R/geom_dia_density.R
+++ b/R/geom_dia_density.R
@@ -8,7 +8,7 @@ GeomDiaDensity <-  ggplot2::ggproto(
   required_aes = c("x"),
   default_aes =
     aes(fill = "grey80", weight = 1, colour = "black",
-        linetype = 1, alpha = NA, size = 0.3,
+        linetype = 1, alpha = NA, linewidth = 0.3,
         lwr = 0.3, upr = 0.98),
   setup_data = Geom$setup_data,
   draw_panel = function(self, data, panel_params, coord, ...) {
@@ -16,7 +16,7 @@ GeomDiaDensity <-  ggplot2::ggproto(
     range <- coord$backtransform_range(panel_params)
 
     # rescale range of density values
-    data$ymax <- corrmorant:::rescale_var(data$density,
+    data$ymax <- rescale_var(data$density,
                                           lower = data$lwr[1],
                                           upper = data$upr[1],
                                           range = range$y,

--- a/R/geom_dia_freqpoly.R
+++ b/R/geom_dia_freqpoly.R
@@ -7,7 +7,7 @@ GeomDiaFreqpoly <-  ggplot2::ggproto(
   "GeomDiaFreqpoly", GeomPath,
   required_aes = "x",
   default_aes =
-    aes(colour = "black", linetype = 1, alpha = NA, size = 0.5,
+    aes(colour = "black", linetype = 1, alpha = NA, linewidth = 0.5,
         lwr = 0.3, upr = 0.98),
   setup_data = Geom$setup_data,
   draw_panel = function(data, panel_params, coord, arrow = NULL,
@@ -17,7 +17,7 @@ GeomDiaFreqpoly <-  ggplot2::ggproto(
     range <- coord$backtransform_range(panel_params)
 
     # rescale range of frequency polygon
-    data$y <- corrmorant:::rescale_var(data$ymax,
+    data$y <- rescale_var(data$ymax,
                                        lower = data$lwr[1],
                                        upper = data$upr[1],
                                        range = range$y,

--- a/R/geom_dia_histogram.R
+++ b/R/geom_dia_histogram.R
@@ -8,7 +8,7 @@ GeomDiaHistogram <- ggplot2::ggproto(
   required_aes = "x",
   default_aes =
     aes(fill = "grey80", colour = NA,
-        linetype = 1, alpha = NA, size = 0.3,
+        linetype = 1, alpha = NA, linewidth = 0.3,
         lwr = 0.3, upr = 0.98),
   setup_data = Geom$setup_data,
   draw_panel = function(self, data, panel_params, coord, width = NULL, ...)
@@ -17,7 +17,7 @@ GeomDiaHistogram <- ggplot2::ggproto(
     range <- coord$backtransform_range(panel_params)
 
     # rescale range of histogram
-    data$ymax <- corrmorant:::rescale_var(data$ymax,
+    data$ymax <- rescale_var(data$ymax,
                                           lower = data$lwr[1],
                                           upper = data$upr[1],
                                           range = range$y,

--- a/R/ggcorrm.R
+++ b/R/ggcorrm.R
@@ -224,21 +224,19 @@ ggcorrm <- function(data,
   }
   facet_arg <- modify_list(list(rows = var_y ~ var_x, scales = "free"), facet_arg)
 
-  # prepare output
-  plot_out <- structure(list(
-    data = corrdat,
-    layers = layers,
-    scales = ggplot()$scales, # cheap hack, must be improved
-    mapping = new_mapping,
-    theme = theme_corrm(),
-    coordinates = coord_cartesian(default = TRUE),
-    facet = do.call(what = facet_grid, args = facet_arg),
-    plot_param = list(corr_method = corr_method, corr_group = corr_group),
-    plot_env = parent.frame()
-  ), class = c( "ggcorrm", "gg", "ggplot"))
+  # prepare output using ggplot() constructor for S7 compatibility (ggplot2 v4+)
+  plot_out <- ggplot(data = corrdat, mapping = new_mapping)
+  plot_out$layers <- layers
+  plot_out$theme <- theme_corrm()
+  plot_out$coordinates <- coord_cartesian(default = TRUE)
+  plot_out$facet <- do.call(what = facet_grid, args = facet_arg)
+  plot_out$plot_env <- parent.frame()
 
-  # get axis labels and scale names
-  plot_out$labels <- make_labels(new_mapping)
+  # store corrmorant-specific parameters (routed to @meta in ggplot2 v4)
+  plot_out$plot_param <- list(corr_method = corr_method, corr_group = corr_group)
+
+  # prepend ggcorrm class for method dispatch
+  class(plot_out) <- c("ggcorrm", class(plot_out))
 
   # update graphics device
   set_last_plot(plot_out)

--- a/R/ggcorrm_build.R
+++ b/R/ggcorrm_build.R
@@ -1,14 +1,14 @@
 # ggplot_build method for ggcorrm objects -------------------------------------
 #' @keywords internal
 #' @export
-ggplot_build.ggcorrm <- function(plot){
+ggplot_build.ggcorrm <- function(plot, ...){
   # update layers to replace missing corrmorant parameters by the plot-level
   # values
   plot$layers <- lapply(plot$layers,
                         update_corrm_param,
                         plot_param = plot$plot_param)
-  # use standard ggplot_build method (imported from ggplot2)
-  ggplot_build.ggplot(plot)
+  # delegate to parent ggplot build method
+  NextMethod()
 }
 
 # helper function for parameter update ----------------------------------------

--- a/R/stat_funtext.R
+++ b/R/stat_funtext.R
@@ -90,7 +90,7 @@ StatFuntext <- ggplot2::ggproto("StatFuntext", StatFuntextProto,
 #'   is evaluated in the context of the raw data and may contain x and y.
 #'
 #'   One outcome of the computation per group is stored in a new column called
-#'   `fun_out` that can be accessed in the aesthetics using`..fun_out..`.
+#'   `fun_out` that can be accessed in the aesthetics using `after_stat(fun_out)`.
 #' @param ... additional arguments passed to [ggplot2::layer()].
 #'
 #' @return An object of class `Layer`.

--- a/R/themes.R
+++ b/R/themes.R
@@ -26,14 +26,14 @@ theme_corrm <- function(base_size = 9, base_family = "",
                         base_line_size = base_size/22,
                         base_rect_size = base_size/22) {
   # built upon theme_grey (standard ggplot theme)
-  theme_grey(base_size,
-             base_family,
-             base_line_size,
-             base_rect_size) %+replace%
+  theme_grey(base_size = base_size,
+             base_family = base_family,
+             base_line_size = base_line_size,
+             base_rect_size = base_rect_size) %+replace%
     theme(aspect.ratio = 1,
           axis.title = element_blank(),
           panel.background = element_blank(),
-          panel.border = element_rect(fill = NA, color = 1),
+          panel.border = element_rect(fill = NA, color = "black"),
           panel.grid.major = element_blank(),
           panel.grid.minor = element_blank(),
           panel.spacing = grid::unit(0, "mm"),


### PR DESCRIPTION
## Summary

Fixes #30. ggplot2 v4.0.0 replaced S3 objects with S7 (`class_ggplot`), which broke corrmorant on load with `object 'ggplot_build.ggplot' not found`. This PR makes corrmorant fully compatible with ggplot2 v4.0.0+.

**This is a clean break — the package now requires `ggplot2 (>= 4.0.0)` and `R (>= 4.1.0)`.**

### Changes (13 files, net -14 lines)

**Critical fixes:**
- **`corrmorant_package.R`**: Remove `getFromNamespace()` calls for `ggplot_build.ggplot` and `make_labels`, which no longer exist as S3 methods in v4
- **`ggcorrm.R`**: Rewrite `ggcorrm()` to use `ggplot()` constructor instead of manual `structure()`. Custom `plot_param` stored via `$` accessor (routed to `@meta` slot in v4)
- **`ggcorrm_build.R`**: Update `ggplot_build.ggcorrm()` to use `NextMethod()` with `...` argument (required by v4 generic signature)
- **`themes.R`**: Use named arguments for `theme_grey()` call — v4 added `header_family` parameter between `base_family` and `base_line_size`, breaking positional matching

**Deprecation fixes:**
- **`add_corrtext.R`, `add_heatmap.R`, `add_heatcircle.R`, `add_funtext.R`**: Replace `..corr..` / `..fun_out..` with `after_stat(corr)` / `after_stat(fun_out)` (deprecated since ggplot2 3.4)
- **`geom_dia_density.R`, `geom_dia_histogram.R`, `geom_dia_freqpoly.R`**: Replace `size` with `linewidth` in `default_aes` for line-based geoms

**Cleanup:**
- Remove `corrmorant:::rescale_var` triple-colon self-references (3 files)
- Update `DESCRIPTION` to require `R (>= 4.1.0)`, `ggplot2 (>= 4.0.0)`

## Test plan

- [x] `devtools::load_all()` — loads without errors
- [x] `devtools::test()` — 98/98 tests pass, 0 failures
- [x] `devtools::check()` — 0 errors, 0 new warnings/notes
- [ ] Manual testing of `?ggcorrm` and `?corrmorant` examples
- [ ] Verify all selector functions (`dia()`, `lotri()`, `utri()`)
- [ ] Verify all layer functions (corrtext, heatmap, heatcircle, density, histogram, freqpoly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)