### PR TITLE
Fix dropped aesthetics warnings (#33)

### DIFF
--- a/R/geom_dia_density.R
+++ b/R/geom_dia_density.R
@@ -1,3 +1,13 @@
+# StatDiaDensity - thin wrapper to suppress "y dropped" warning ---------------
+#' @rdname corrmorant_ggproto
+#' @format NULL
+#' @usage NULL
+#' @export
+StatDiaDensity <- ggplot2::ggproto(
+  "StatDiaDensity", ggplot2::StatDensity,
+  dropped_aes = c("y", "weight")
+)
+
 # GeomDiaDensity - ggproto object for geom_dia_density ------------------------
 #' @rdname corrmorant_ggproto
 #' @format NULL
@@ -65,7 +75,7 @@ GeomDiaDensity <-  ggplot2::ggproto(
 #' @export
 geom_dia_density <- function(mapping = NULL,
                           data = NULL,
-                          stat = "density",
+                          stat = StatDiaDensity,
                           position = "identity",
                           ...,
                           na.rm = FALSE,

--- a/R/stat_corrtext.R
+++ b/R/stat_corrtext.R
@@ -7,6 +7,7 @@
 StatCorrtextProto <- ggplot2::ggproto(
   "StatCorrtextProto", Stat,
   required_aes = c("x", "y"),
+  dropped_aes  = c("x", "y"),
   # compute_group
   compute_group = function (data, scales,
                             nrow = NULL, ncol = NULL,
@@ -28,6 +29,7 @@ StatCorrtextProto <- ggplot2::ggproto(
 #' @export
 StatCorrtext <- ggplot2::ggproto(
   "StatCorrtext", StatCorrtextProto,
+  dropped_aes   = c("x", "y"),
   extra_params  = c("na.rm", "corr_method"),
   # compute panel - standard function just slightly updated to pass ranges
   compute_panel = function (self, data, scales,

--- a/R/stat_funtext.R
+++ b/R/stat_funtext.R
@@ -6,6 +6,7 @@
 #' @export
 StatFuntextProto <- ggplot2::ggproto("StatFuntextProto", Stat,
     required_aes = c("x", "y"),
+    dropped_aes  = c("x", "y"),
    # compute_group
    compute_group = function (data, scales,
                              fun,
@@ -26,6 +27,7 @@ StatFuntextProto <- ggplot2::ggproto("StatFuntextProto", Stat,
 #' @usage NULL
 #' @export
 StatFuntext <- ggplot2::ggproto("StatFuntext", StatFuntextProto,
+   dropped_aes  = c("x", "y"),
    required_aes = c("x", "y"),
    # compute panel - standard function just slightly updated to pass ranges
    compute_panel = function (self, data, scales, fun,


### PR DESCRIPTION
## Summary

- Add `dropped_aes = c("x", "y")` to `StatCorrtextProto`, `StatCorrtext`, `StatFuntextProto`, and `StatFuntext` — these stats intentionally consume x/y to compute correlations/functions, then create new positional coordinates in `compute_panel`
- Create `StatDiaDensity` wrapper around `StatDensity` with `dropped_aes = c("y", "weight")` and use it as default stat in `geom_dia_density()` — the inherited `y` from ggcorrm is not used by density computation
- Eliminates all 10 "aesthetics were dropped during statistical transformation" warnings from `corrmorant(drosera)`

Closes #33

## Test plan

- [x] `corrmorant(drosera)` produces no warnings for all 4 styles (blue_red, dark, light, binned)
- [x] All 159 existing tests pass (0 failures)
- [x] Plots render identically (no behavioural changes, only warning suppression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)