### PR TITLE
Fix dia_histogram baseline shift on unrescaled data (#36)

### DIFF
--- a/R/geom_dia_histogram.R
+++ b/R/geom_dia_histogram.R
@@ -21,7 +21,7 @@ GeomDiaHistogram <- ggplot2::ggproto(
                                           lower = data$lwr[1],
                                           upper = data$upr[1],
                                           range = range$y,
-                                          append_x = 0)
+                                          append_x = range$y[1])
     data$ymin <- range$y[1] + 0.99 * data$lwr[1] * diff(range$y)
 
     # return grob


### PR DESCRIPTION
## Summary
- Use `range$y[1]` instead of literal `0` as `append_x` in the geom's `rescale_var()` call
- When the y-range doesn't start at 0 (i.e. data on its original scale), appending `0` extended the effective rescaling range and shifted the histogram baseline upward

Fixes #36

## Test plan
- [ ] `ggcorrm(drosera) + dia_histogram()` renders consistent baselines across panels
- [ ] `ggcorrm(drosera, rescale = "by_sd") + dia_histogram()` still renders correctly
- [ ] All 159 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)